### PR TITLE
Refactor: renamed hostname to premiere

### DIFF
--- a/client/ayon_premiere/hooks/pre_launch_install_ayon_extension.py
+++ b/client/ayon_premiere/hooks/pre_launch_install_ayon_extension.py
@@ -24,7 +24,7 @@ class InstallAyonExtensionToPremiere(PreLaunchHook):
 
     def execute(self):
         try:
-            settings = self.data["project_settings"][self.host_name]
+            settings = self.data["project_settings"]["premiere"]
             if not settings["hooks"]["InstallAyonExtensionToPremiere"][
                 "enabled"
             ]:


### PR DESCRIPTION
## Changelog Description
Use explicit addon name instead of host name to get addon settings.
[Direct Port of](https://github.com/ynput/ayon-fusion/pull/35)

## Additional review information
Because addon name and host name are same it did work, but code-wise is confusing. It should look explicitly for addon name, not host name (confusing those who use other addons as example).

## Testing notes:
1. Validate the reasoning of the change.
2. Nothing really changed technically.