### PR TITLE
Set auto install On by default

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -3,12 +3,12 @@ from ayon_server.settings import BaseSettingsModel, SettingsField
 
 class PremiereSettings(BaseSettingsModel):
     auto_install_extension: bool = SettingsField(
-        False,
+        True,
         title="Install AYON Extension",
         description="Triggers pre-launch hook which installs extension."
     )
 
 
 DEFAULT_VALUES = {
-    "auto_install_extension": False
+    "auto_install_extension": True
 }


### PR DESCRIPTION
## Changelog Description
Premiere implementation is new, there is very small chance that anyone installed extension manually.


## Testing notes:
1. check that it is enabled in Settings
![image](https://github.com/user-attachments/assets/3418b313-49d9-4f3a-9d01-5850839588c5)

