### PR TITLE
Move from using env var to Tools Settings to open Workfiles on startup

### DIFF
--- a/client/ayon_premiere/api/launch_logic.py
+++ b/client/ayon_premiere/api/launch_logic.py
@@ -14,7 +14,7 @@ from wsrpc_aiohttp import (
 
 from qtpy import QtCore
 
-from ayon_core.lib import Logger, is_in_tests
+from ayon_core.lib import Logger, is_in_tests, env_value_to_bool
 from ayon_core.pipeline import install_host
 from ayon_core.addon import AddonsManager
 from ayon_core.tools.utils import host_tools, get_ayon_qt_app
@@ -47,6 +47,9 @@ def main(*subprocess_args):
     launcher = ProcessLauncher(subprocess_args)
     launcher.start()
 
+    env_workfiles_on_launch = os.getenv("AYON_PREMIERE_WORKFILES_ON_LAUNCH")
+    workfiles_on_launch = env_value_to_bool(value=env_workfiles_on_launch)
+
     if is_in_tests():
         manager = AddonsManager()
         premiere_addon = manager["premiere"]
@@ -59,7 +62,7 @@ def main(*subprocess_args):
             )
         )
 
-    elif os.environ.get("AYON_PREMIERE_WORKFILES_ON_LAUNCH", True):
+    elif workfiles_on_launch:
         save = False
         if os.getenv("WORKFILES_SAVE_AS"):
             save = True

--- a/client/ayon_premiere/hooks/pre_launch_args.py
+++ b/client/ayon_premiere/hooks/pre_launch_args.py
@@ -77,6 +77,11 @@ class PremierePrelaunchHook(PreLaunchHook):
         ):
             new_launch_args.append(workfile_path)
 
+        workfile_startup = self.data.get("workfile_startup", False)
+        self.launch_context.env["AYON_PREMIERE_WORKFILES_ON_LAUNCH"] = (
+            str(workfile_startup).lower()
+        )
+
         # Append as whole list as these arguments should not be separated
         self.launch_context.launch_args.append(new_launch_args)
 


### PR DESCRIPTION
## Changelog Description
Previously opening of `Workfiles` app was controlled by old env var in Applications addon, now it should be configured by Tools > Workfiles Settings which are more granular.

! This changes default state of opening Workfiles app to NOT OPEN them (unless updated in `ayon+settings://core/tools/Workfiles/open_workfile_tool_on_startup`)

## Testing notes:
1. remove `AYON_PREMIERE_WORKFILES_ON_LAUNCH` line in `ayon+settings://applications/applications/premiere`
2.  experiment with `ayon+settings://core/tools/Workfiles/open_workfile_tool_on_startup`