### PR TITLE
Chore: Use new workfiles API to increment current workfile.

### DIFF
--- a/client/ayon_premiere/plugins/publish/increment_workfile.py
+++ b/client/ayon_premiere/plugins/publish/increment_workfile.py
@@ -1,8 +1,11 @@
-import pyblish.api
-from ayon_core.lib import version_up
-from ayon_core.pipeline.publish import get_errored_plugins_from_context
+import os
 
-from ayon_premiere.api import get_stub
+import pyblish.api
+
+from ayon_core.lib import version_up
+from ayon_core.host import IWorkfileHost
+from ayon_core.pipeline import registered_host
+from ayon_core.pipeline.publish import get_errored_plugins_from_context
 
 
 class IncrementWorkfile(pyblish.api.InstancePlugin):
@@ -18,13 +21,39 @@ class IncrementWorkfile(pyblish.api.InstancePlugin):
     optional = True
 
     def process(self, instance):
-        errored_plugins = get_errored_plugins_from_context(instance.context)
+        context: pyblish.api.Context = instance.context
+        errored_plugins = get_errored_plugins_from_context(context)
         if errored_plugins:
             raise RuntimeError(
                 "Skipping incrementing current file because publishing failed."
             )
 
-        scene_path = version_up(instance.context.data["currentFile"])
-        get_stub().saveAs(scene_path, True)
+        host: IWorkfileHost = registered_host()
+        current_filepath: str = context.data["currentFile"]
+        try:
+            from ayon_core.pipeline.workfile import save_next_version
+            from ayon_core.host.interfaces import SaveWorkfileOptionalData
 
-        self.log.info("Incremented workfile to: {}".format(scene_path))
+            current_filename = os.path.basename(current_filepath)
+            save_next_version(
+                description=(
+                    f"Incremented by publishing from {current_filename}"
+                ),
+                # Optimize the save by reducing needed queries for context
+                prepared_data=SaveWorkfileOptionalData(
+                    project_entity=context.data["projectEntity"],
+                    project_settings=context.data["project_settings"],
+                    anatomy=context.data["anatomy"],
+                )
+            )
+            new_filepath = host.get_current_workfile()
+        except ImportError:
+            # Backwards compatibility before ayon-core 1.5.0
+            self.log.debug(
+                "Using legacy `version_up`. Update AYON core addon to "
+                "use newer `save_next_version` function."
+            )
+            new_filepath = version_up(current_filepath)
+            host.save_workfile(new_filepath)
+
+        self.log.debug(f"Incremented workfile to: {new_filepath}")


### PR DESCRIPTION
## Changelog Description

When incrementing the workfile during publish, use the new context-based workfile API so that the current author information is stored with the saved file.

## Additional review information

<img width="260" height="113" alt="image" src="https://github.com/user-attachments/assets/4f20a81e-e437-46d2-a0cf-66092b20d8de" />

_screenshot from maya_

Requires ayon-core 1.5.0 to test the added comment (aka artist note) and the author data to come through.

## Testing notes:

1. Publishing should work
2. Workfile should be incremented
3. Workfile should show the author of the publish 
4. Workfile should have 'artist note' set: "Incremented by publishing."
