### PR TITLE
🏛️Product base types: Product types and base types

### DIFF
--- a/client/ayon_premiere/plugins/create/workfile_creator.py
+++ b/client/ayon_premiere/plugins/create/workfile_creator.py
@@ -8,8 +8,8 @@ from ayon_premiere.api.pipeline import cache_and_get_instances
 
 class PremiereWorkfileCreator(AutoCreator):
     identifier = "workfile"
-    product_type = "workfile"
     product_base_type = "workfile"
+    product_type = product_base_type
 
     default_variant = "Main"
 
@@ -17,12 +17,17 @@ class PremiereWorkfileCreator(AutoCreator):
         return []
 
     def collect_instances(self):
+        product_type = self.product_type or self.product_base_type
         for instance_data in cache_and_get_instances(self):
             creator_id = instance_data.get("creator_identifier")
             if creator_id == self.identifier:
                 product_name = instance_data["productName"]
                 instance = CreatedInstance(
-                    self.product_type, product_name, instance_data, self
+                    product_base_type=self.product_base_type,
+                    product_type=product_type,
+                    product_name=product_name,
+                    data=instance_data,
+                    creator=self,
                 )
                 self._add_instance_to_context(instance)
 
@@ -33,7 +38,7 @@ class PremiereWorkfileCreator(AutoCreator):
     def create(self, options=None):
         existing_instance = None
         for instance in self.create_context.instances:
-            if instance.product_type == self.product_type:
+            if instance.product_base_type == self.product_base_type:
                 existing_instance = instance
                 break
 
@@ -50,6 +55,7 @@ class PremiereWorkfileCreator(AutoCreator):
         if existing_instance is not None:
             existing_folder_path = existing_instance.get("folderPath")
 
+        product_type = self.product_type or self.product_base_type
         if existing_instance is None:
             product_name = self.get_product_name(
                 project_name=project_name,
@@ -58,21 +64,13 @@ class PremiereWorkfileCreator(AutoCreator):
                 task_entity=task_entity,
                 variant=self.default_variant,
                 host_name=host_name,
+                product_type=product_type,
             )
             data = {
                 "folderPath": folder_path,
                 "task": task_name,
                 "variant": self.default_variant,
             }
-            data.update(self.get_dynamic_data(
-                project_name,
-                folder_entity,
-                task_entity,
-                self.default_variant,
-                host_name,
-                None,
-            ))
-
             new_instance = CreatedInstance(
                 self.product_type, product_name, data, self
             )
@@ -93,6 +91,7 @@ class PremiereWorkfileCreator(AutoCreator):
                 task_entity=task_entity,
                 variant=self.default_variant,
                 host_name=host_name,
+                product_type=product_type,
             )
             existing_instance["folderPath"] = folder_path
             existing_instance["task"] = task_name

--- a/client/ayon_premiere/plugins/load/load_aftereffects_comp.py
+++ b/client/ayon_premiere/plugins/load/load_aftereffects_comp.py
@@ -15,7 +15,8 @@ class AECompLoader(api.PremiereLoader):
     """
     label = "Load AfterEffects Compositions"
     icon = "image"
-    product_types = {"workfile"}
+    product_base_types = {"workfile"}
+    product_types = product_base_types
     representations = {"aep"}
 
     def load(

--- a/client/ayon_premiere/plugins/load/load_file.py
+++ b/client/ayon_premiere/plugins/load/load_file.py
@@ -22,7 +22,8 @@ class FileLoader(api.PremiereLoader):
     label = "Load file"
     icon = "image"
 
-    product_types: set[str] = {"*"}
+    product_base_types: set[str] = {"*"}
+    product_types = product_base_types
     representations: set[str] = {"*"}
     extensions: set[str] = set(
         ext.lstrip(".") for ext in IMAGE_EXTENSIONS.union(VIDEO_EXTENSIONS)

--- a/client/ayon_premiere/plugins/publish/collect_workfile.py
+++ b/client/ayon_premiere/plugins/publish/collect_workfile.py
@@ -20,7 +20,7 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
     def process(self, context):
         workfile_instance = None
         for instance in context:
-            if instance.data["productType"] == "workfile":
+            if instance.data["productBaseType"] == "workfile":
                 self.log.debug("Workfile instance found")
                 workfile_instance = instance
                 break

--- a/package.py
+++ b/package.py
@@ -7,6 +7,6 @@ project_can_override_addon_version = True
 
 ayon_server_version = ">=1.1.2"
 ayon_required_addons = {
-    "core": ">=1.0.0",
+    "core": ">=1.8.0",
 }
 ayon_compatible_addons = {}


### PR DESCRIPTION
## Changelog Description
Use product base types.

## Additional review information
Codebase of Premiere is fully using product base type as "pipeline" type. Load plugins define `product_base_types` for filtering, create plugins do define `product_base_type` and the whole logic is expecting that product base type is being used in the system.

At this moment there are no product type aliases, yet.

## Testing notes:
### Basics
1. Use ayon-core >= 1.8.0 or current develop if is not released yet.
2. Existing workfiles should load up and should be possible to publish.
3. Publishing of workfiles works too.