### PR TITLE
Loaders: Filters by extension instead of representation name

### DIFF
--- a/client/ayon_premiere/plugins/load/load_aftereffects_comp.py
+++ b/client/ayon_premiere/plugins/load/load_aftereffects_comp.py
@@ -16,7 +16,8 @@ class AECompLoader(api.PremiereLoader):
     label = "Load AfterEffects Compositions"
     icon = "image"
     product_types = {"workfile"}
-    representations = {"aep"}
+    representations = {"*"}
+    extensions = {"aep"}
 
     def load(
         self,


### PR DESCRIPTION
## Changelog Description

Loaders: Filters by extension instead of representation name

## Additional review information

Make loaders filter by extension instead of representation name so they are less restrictive on what can be loaded.

## Testing notes:

1. Validate code changes
2. Loaders should still be able to load the right representations, etc.