### PR TITLE
Launch hook: Handle 'workfile_path'

### DIFF
--- a/client/ayon_premiere/hooks/pre_launch_args.py
+++ b/client/ayon_premiere/hooks/pre_launch_args.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import platform
 import subprocess
@@ -69,12 +71,8 @@ class PremierePrelaunchHook(PreLaunchHook):
             "run", script_path, executable_path
         )
         # Add workfile path if exists
-        workfile_path = self.data["last_workfile_path"]
-        if (
-            self.data.get("start_last_workfile")
-            and workfile_path
-            and os.path.exists(os.path.normpath(workfile_path))
-        ):
+        workfile_path = self.get_workfile_path()
+        if workfile_path:
             new_launch_args.append(os.path.normpath(workfile_path))
 
         workfile_startup = self.data.get("workfile_startup", False)
@@ -91,3 +89,16 @@ class PremierePrelaunchHook(PreLaunchHook):
         self.launch_context.kwargs = get_launch_kwargs(
             self.launch_context.kwargs
         )
+
+    def get_workfile_path(self) -> str | None:
+        workfile_path = self.data.get("workfile_path")
+        if workfile_path:
+            return workfile_path
+
+        if not self.data.get("start_last_workfile"):
+            return None
+
+        last_workfile_path = self.data.get("last_workfile_path")
+        if last_workfile_path and os.path.exists(last_workfile_path):
+            return last_workfile_path
+        return None


### PR DESCRIPTION
## Changelog Description
Handle explicit workfile path in launch hook.

## Additional review information
Key `workfile_path` is set if explicit (existing) workfile path shoud be used for launching.

## Testing notes:
1. Launch of premiere on workfile entity from launcher does launch the workfile.
