### PR TITLE
Store and Restore original trims for image sequences

### DIFF
--- a/client/ayon_premiere/api/extension/jsx/hostscript.jsx
+++ b/client/ayon_premiere/api/extension/jsx/hostscript.jsx
@@ -551,8 +551,21 @@ function repointMediaInSequences(oldItem, newItem, fullReplace) {
                 if (clip.projectItem
                     && clip.projectItem.nodeId === oldItem.nodeId) {
                     if (fullReplace){
+                        // Store the original trims
+                        var originalInTicks = clip.inPoint.ticks;
+                        var originalOutTicks = clip.outPoint.ticks;
+
                         // Replace the project item with the new item
                         clip.projectItem = newItem;
+
+                        // Restore the original trims
+                        var restoredIn = new Time();
+                        restoredIn.ticks = originalInTicks;
+                        clip.inPoint = restoredIn;
+
+                        var restoredOut = new Time();
+                        restoredOut.ticks = originalOutTicks;
+                        clip.outPoint = restoredOut;
                     }
 
                     clip.name = newItem.name;


### PR DESCRIPTION
Image Sequence currently doesn't maintain their edits in Premiere when using AYON Manager.

This PR tries to solve that by saving the in and out points of the clip and reapplying it after the new item has been imported.

## Testing notes:
1. Load an image sequence 
2. Cut the clip, trim the front and the back etc.
3. Update the clip to a new version and check if the edits still remain.

Not too sure if I need to update the extension.zxp for this pull request or this would be done at the end when a new addon is about to be made. 